### PR TITLE
Simpler output for easy mode

### DIFF
--- a/phylogenetic-signal/Phylogenetic signal.json
+++ b/phylogenetic-signal/Phylogenetic signal.json
@@ -1,0 +1,48 @@
+{
+    "inputs": [
+        {
+            "format": "r.dataframe",
+            "name": "table",
+            "type": "table"
+        },
+        {
+            "format": "r.apetree",
+            "name": "tree",
+            "type": "tree"
+        },
+        {
+            "domain": {
+                "format": "column.names",
+                "input": "table"
+            },
+            "format": "text",
+            "name": "column",
+            "type": "string"
+        },
+        {
+            "default": "[object Object]",
+            "domain": [
+                "lambda",
+                "K"
+            ],
+            "format": "text",
+            "name": "method",
+            "type": "string"
+        }
+    ],
+    "mode": "r",
+    "name": "Phylogenetic signal",
+    "outputs": [
+        {
+            "format": "r.dataframe",
+            "name": "result",
+            "type": "table"
+        },
+        {
+            "name": "analysisType",
+            "type": "string",
+            "format": "text"
+        }
+    ],
+    "script": "#data(anolis); tree <- anolis$phy; table <- anolis$dat; column <- \"SVL\"; method <- \"lambda\"; discreteModelType=\"ER\"\nlibrary(devtools)\n#options(repos=\"http://cran.cnr.Berkeley.edu\")\n#install_github(\"arborworkflows/aRbor\")\n# measure phylogenetic signal\nrequire(aRbor)\n\n# Names and data match - so data integrator might be needed at this step\n# (in general) but is not needed in this case.\n\ntd <- make.treedata(tree, table)\ntd <- select(td, which(colnames(td$dat)==column))\nphy <- td$phy\ndat <- td$dat\n\ncharType <- aRbor:::detectCharacterType(dat[[1]], cutoff=0.2)\n\nif(charType==\"discrete\"){\n  result <- physigArbor(td, charType=charType, signalTest=\"pagelLambda\")\n  analysisType <- \"discrete lambda\"\n}\nif(charType==\"continuous\"){\n  if(method==\"lambda\") {\n    result <- physigArbor(td, charType=charType, signalTest=\"pagelLambda\")\n    analysisType <- \"continuous lambda\"\n  }\n  \n  if(method==\"K\") {\n    result <- physigArbor(td, charType=charType, signalTest=\"Blomberg\")\n    analysisType <- \"continuous K\"\n  \n  }\n}\n\nresult <- t(as.data.frame(unlist(result)))\nrownames(result) <- NULL\n"
+}

--- a/phylogenetic-signal/index.html
+++ b/phylogenetic-signal/index.html
@@ -100,7 +100,7 @@ html, body {
                 </div>
             </div>
             <div class="row">
-                <div id="result" class="col-sm-12 text-center">
+                <div id="result" class="col-sm-12 full-width">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This changes the easy mode phylogenetic-signal output from a table to text that I hope will be easier for end-users to read. I had to alter the function as well because I think it is important to return "analysis-type" - so I include also the json file.